### PR TITLE
fix(goreleaser): pass HOMEBREW_TAP_GITHUB_TOKEN to cask push

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,4 +69,5 @@ homebrew_casks:
   - repository:
       owner: jtprogru
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks


### PR DESCRIPTION
## Summary
Release 0.5.2 built and uploaded all artifacts but failed to publish the Homebrew cask: \`403 Resource not accessible by integration\` when pushing to \`jtprogru/homebrew-tap\`. Root cause: \`homebrew_casks\` was using the default \`GITHUB_TOKEN\` (scoped to this repo only) instead of the \`HOMEBREW_TAP_GITHUB_TOKEN\` secret. Reference the token explicitly via \`repository.token\`.

Failed run: https://github.com/jtprogru/repo-opener/actions/runs/25429095799

## Test plan
- [ ] Merge, then re-tag (delete & recreate \`0.5.2\`, or bump to \`0.5.3\`)
- [ ] Verify cask appears in jtprogru/homebrew-tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)