### PR TITLE
docs(readme): add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,17 @@ Simple utility that prints the current Git repository's remote HTTP URL — work
 
 ## Installation
 
-For installation you need to load latest version from [Release](https://github.com/jtprogru/repo-opener/releases) page and download version for you platform.
+### Homebrew (macOS / Linux)
 
-Another way is usage `go install`:
+```sh
+brew install jtprogru/tap/repo-opener
+```
+
+### Pre-built binaries
+
+Download the archive for your platform from the [Releases](https://github.com/jtprogru/repo-opener/releases) page.
+
+### `go install`
 
 ```sh
 # Get latest version from CLI


### PR DESCRIPTION
## Summary
- Document \`brew install jtprogru/tap/repo-opener\` now that the Homebrew tap is being published by goreleaser.
- Restructure Installation into three options: Homebrew, pre-built binaries, \`go install\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)