### PR TITLE
refactor(url): unify validation, sentinel errors, scp/git protocol support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist/
 .gocache/
 .mcp.json
 cover.out
+repo-opener

--- a/main.go
+++ b/main.go
@@ -13,12 +13,26 @@ import (
 )
 
 const (
-	ErrOriginRemoteNotFound = "origin remote not found"
-	ErrEmptyRepositoryPath  = "empty repository path"
-
 	GitHubHost    = "github.com"
 	GitLabHost    = "gitlab.com"
 	BitbucketHost = "bitbucket.org"
+
+	// minPathSegments — минимальное число сегментов пути (owner/repo).
+	minPathSegments = 2
+	// scpURLParts — число частей при разборе scp-URL по первому двоеточию.
+	scpURLParts = 2
+)
+
+// Sentinel-ошибки для программной проверки через errors.Is.
+var (
+	ErrRemoteNotFound        = errors.New("remote not found")
+	ErrEmptyRepositoryPath   = errors.New("empty repository path")
+	ErrInvalidRepositoryPath = errors.New("invalid repository path")
+	ErrUnsupportedURLFormat  = errors.New("unsupported URL format")
+	ErrInvalidSSHURL         = errors.New("invalid SSH URL format")
+	ErrUnsupportedScheme     = errors.New("unsupported scheme")
+	ErrUnsupportedSSHUser    = errors.New("unsupported SSH username")
+	ErrInvalidResultURL      = errors.New("invalid resulting URL")
 )
 
 var (
@@ -76,28 +90,45 @@ func getRemoteURL(repo *git.Repository, name string) (string, error) {
 	}
 
 	for _, remote := range remotes {
-		if remote.Config().Name == name {
-			if len(remote.Config().URLs) > 0 {
-				return remote.Config().URLs[0], nil
-			}
+		cfg := remote.Config()
+		if cfg.Name == name && len(cfg.URLs) > 0 {
+			return cfg.URLs[0], nil
 		}
 	}
 
-	return "", fmt.Errorf("remote %q not found", name)
+	return "", fmt.Errorf("%w: %q", ErrRemoteNotFound, name)
 }
 
 func parseRemoteURL(remoteURL string) (string, error) {
-	// Пытаемся парсить как стандартный URL.
+	// scp-подобный формат [user@]host:path разбираем до url.Parse, потому что
+	// "host:path" парсер ошибочно принимает за схему ("host").
+	if isSCPLikeURL(remoteURL) {
+		return parseSCPURL(remoteURL)
+	}
+
+	// Стандартный URL со схемой (http(s), ssh, git).
 	if u, err := url.Parse(remoteURL); err == nil && u.Scheme != "" {
 		return parseStructuredURL(u)
 	}
 
-	// Обрабатываем SSH-формат (git@host:path).
-	if strings.HasPrefix(remoteURL, "git@") {
-		return parseSSHURL(remoteURL)
+	return "", fmt.Errorf("%w: %s", ErrUnsupportedURLFormat, remoteURL)
+}
+
+// isSCPLikeURL сообщает, что строка имеет scp-подобный вид [user@]host:path:
+// содержит двоеточие раньше первого слэша и не содержит "://".
+func isSCPLikeURL(remoteURL string) bool {
+	if strings.Contains(remoteURL, "://") {
+		return false
 	}
 
-	return "", fmt.Errorf("unsupported URL format: %s", remoteURL)
+	colon := strings.IndexByte(remoteURL, ':')
+	if colon < 0 {
+		return false
+	}
+
+	slash := strings.IndexByte(remoteURL, '/')
+
+	return slash < 0 || colon < slash
 }
 
 func parseStructuredURL(u *url.URL) (string, error) {
@@ -107,41 +138,42 @@ func parseStructuredURL(u *url.URL) (string, error) {
 	case "http", "https":
 		host = u.Host
 		path = u.Path
-	case "ssh":
-		host = u.Host
+	case "ssh", "git":
+		// Для ssh/git порт относится к транспорту, а не к веб-интерфейсу,
+		// поэтому отбрасываем его через Hostname().
+		host = u.Hostname()
 		path = u.Path
-		if u.User != nil && u.User.Username() != "git" {
-			return "", fmt.Errorf("unsupported SSH username: %s", u.User.Username())
+		if u.Scheme == "ssh" && u.User != nil && u.User.Username() != "git" {
+			return "", fmt.Errorf("%w: %s", ErrUnsupportedSSHUser, u.User.Username())
 		}
 	default:
-		return "", fmt.Errorf("unsupported scheme: %s", u.Scheme)
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedScheme, u.Scheme)
 	}
 
 	if path == "" {
-		return "", errors.New("empty repository path")
+		return "", ErrEmptyRepositoryPath
 	}
 
 	return buildWebURL(host, path)
 }
 
-func parseSSHURL(remoteURL string) (string, error) {
-	parts := strings.SplitN(remoteURL, ":", 2)
-	if len(parts) != 2 {
-		return "", errors.New("invalid SSH URL format")
+func parseSCPURL(remoteURL string) (string, error) {
+	parts := strings.SplitN(remoteURL, ":", scpURLParts)
+	if len(parts) != scpURLParts {
+		return "", ErrInvalidSSHURL
 	}
 
-	host := strings.TrimPrefix(parts[0], "git@")
-	path := strings.Trim(parts[1], "/")
-
-	if path == "" {
-		return "", errors.New(ErrEmptyRepositoryPath)
+	// Отбрасываем необязательный [user@] — для веб-URL имя пользователя не нужно.
+	host := parts[0]
+	if at := strings.LastIndexByte(host, '@'); at >= 0 {
+		host = host[at+1:]
 	}
 
-	if len(strings.Split(path, "/")) < 2 {
-		return "", errors.New("invalid SSH URL format")
+	if host == "" {
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedURLFormat, remoteURL)
 	}
 
-	return buildWebURL(host, path)
+	return buildWebURL(host, strings.Trim(parts[1], "/"))
 }
 
 func buildWebURL(hostOrigin, path string) (string, error) {
@@ -151,7 +183,12 @@ func buildWebURL(hostOrigin, path string) (string, error) {
 	// Удаляем .git в конце пути и ведущие/конечные слэши.
 	cleanPath := strings.Trim(strings.TrimSuffix(path, ".git"), "/")
 	if cleanPath == "" {
-		return "", errors.New(ErrEmptyRepositoryPath)
+		return "", ErrEmptyRepositoryPath
+	}
+
+	// Путь к репозиторию всегда состоит как минимум из owner/repo.
+	if len(strings.Split(cleanPath, "/")) < minPathSegments {
+		return "", fmt.Errorf("%w: %s", ErrInvalidRepositoryPath, cleanPath)
 	}
 
 	// Нормализуем хост только для публичных Git-платформ.
@@ -167,7 +204,20 @@ func buildWebURL(hostOrigin, path string) (string, error) {
 		// Приватные инсталляции сохраняем как есть.
 	}
 
-	return fmt.Sprintf("%s%s/%s", "https://", host, cleanPath), nil
+	webURL := fmt.Sprintf("%s%s/%s", "https://", host, cleanPath)
+
+	// Defense-in-depth: убеждаемся, что собранная строка — корректный https-URL
+	// с непустым хостом, прежде чем выводить её или открывать в браузере.
+	parsed, err := url.Parse(webURL)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidResultURL, err)
+	}
+
+	if parsed.Scheme != "https" || parsed.Hostname() == "" {
+		return "", fmt.Errorf("%w: %s", ErrInvalidResultURL, webURL)
+	}
+
+	return webURL, nil
 }
 
 func exitWithError(err error) {

--- a/main_test.go
+++ b/main_test.go
@@ -62,8 +62,8 @@ func TestGetRemoteURL(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = getRemoteURL(repo, "nonexistent")
-		require.Error(t, err)
-		assert.ErrorContains(t, err, `remote "nonexistent" not found`)
+		require.ErrorIs(t, err, ErrRemoteNotFound)
+		assert.ErrorContains(t, err, "nonexistent")
 	})
 }
 
@@ -106,6 +106,30 @@ func TestParseRemoteURL(t *testing.T) {
 	require.NoError(t, err, "Expected no error for valid SSH URL")
 	assert.Equal(t, "https://bitbucket.org/org/repo", webURL)
 
+	// Test case: ssh:// scheme with SSH port is stripped.
+	webURL, err = parseRemoteURL("ssh://git@github.com:22/org/repo.git")
+	require.NoError(t, err, "Expected no error for ssh:// URL with port")
+	assert.Equal(t, "https://github.com/org/repo", webURL)
+
+	// Test case: git:// protocol is supported.
+	webURL, err = parseRemoteURL("git://github.com/org/repo.git")
+	require.NoError(t, err, "Expected no error for git:// URL")
+	assert.Equal(t, "https://github.com/org/repo", webURL)
+
+	// Test case: scp-like URL without git@ user.
+	webURL, err = parseRemoteURL("github.com:org/repo.git")
+	require.NoError(t, err, "Expected no error for scp-like URL without user")
+	assert.Equal(t, "https://github.com/org/repo", webURL)
+
+	// Test case: scp-like URL with a custom user.
+	webURL, err = parseRemoteURL("org-ssh@github.com:org/repo.git")
+	require.NoError(t, err, "Expected no error for scp-like URL with custom user")
+	assert.Equal(t, "https://github.com/org/repo", webURL)
+
+	// Test case: single-segment path is rejected (http).
+	_, err = parseRemoteURL("https://github.com/onlyuser")
+	require.ErrorIs(t, err, ErrInvalidRepositoryPath)
+
 	// Test case: invalid SSH URL.
 	invalidSSHURL := "git@github.com:user"
 	_, err = parseRemoteURL(invalidSSHURL)
@@ -114,7 +138,7 @@ func TestParseRemoteURL(t *testing.T) {
 	// Test case: unsupported URL format.
 	invalidURL := "ftp://example.com/repo.git"
 	_, err = parseRemoteURL(invalidURL)
-	require.Error(t, err, "Expected error for unsupported URL format")
+	require.ErrorIs(t, err, ErrUnsupportedScheme)
 }
 
 func TestParseStructuredURL(t *testing.T) {
@@ -129,37 +153,56 @@ func TestParseStructuredURL(t *testing.T) {
 	// Test case: missing path.
 	u, _ = url.Parse("https://github.com") //nolint:errcheck // Ignore error from url.Parse
 	_, err = parseStructuredURL(u)
-	require.Error(t, err, "Expected error for empty repository path")
+	require.ErrorIs(t, err, ErrEmptyRepositoryPath)
+
+	// Test case: ssh scheme with port is stripped from the web host.
+	u, _ = url.Parse("ssh://git@github.com:22/jtprogru/repo-opener.git") //nolint:errcheck // Ignore error from url.Parse
+	webURL, err = parseStructuredURL(u)
+	require.NoError(t, err, "Expected no error for ssh URL with port")
+	assert.Equal(t, "https://github.com/jtprogru/repo-opener", webURL)
+
+	// Test case: git scheme is supported.
+	u, _ = url.Parse("git://github.com/jtprogru/repo-opener.git") //nolint:errcheck // Ignore error from url.Parse
+	webURL, err = parseStructuredURL(u)
+	require.NoError(t, err, "Expected no error for git scheme")
+	assert.Equal(t, "https://github.com/jtprogru/repo-opener", webURL)
 
 	// Test case: ssh scheme with invalid user.
 	u, _ = url.Parse("ssh://user@github.com/jtprogru/repo-opener.git") //nolint:errcheck // Ignore error from url.Parse
 	_, err = parseStructuredURL(u)
-	require.Error(t, err, "Expected error for unsupported SSH username")
+	require.ErrorIs(t, err, ErrUnsupportedSSHUser)
 
 	// Test case: unsupported scheme.
 	u, _ = url.Parse("ftp://example.com/repo.git") //nolint:errcheck // Ignore error from url.Parse
 	_, err = parseStructuredURL(u)
-	require.Error(t, err, "Expected error for unsupported scheme")
+	require.ErrorIs(t, err, ErrUnsupportedScheme)
 }
 
-func TestParseSSHURL(t *testing.T) {
+func TestParseSCPURL(t *testing.T) {
 	t.Parallel()
 
 	// Test case: valid SSH URL.
 	sshURL := "git@github.com:jtprogru/repo-opener.git"
-	webURL, err := parseSSHURL(sshURL)
+	webURL, err := parseSCPURL(sshURL)
 	require.NoError(t, err, "Expected no error for valid SSH URL")
 	assert.Equal(t, "https://github.com/jtprogru/repo-opener", webURL)
 
-	// Test case: invalid SSH URL.
-	invalidSSHURL := "git@github.com:user"
-	_, err = parseSSHURL(invalidSSHURL)
-	require.Error(t, err, "Expected error for invalid SSH URL")
+	// Test case: custom user is discarded.
+	webURL, err = parseSCPURL("org-ssh@gitlab.com:org/repo.git")
+	require.NoError(t, err, "Expected no error for custom user")
+	assert.Equal(t, "https://gitlab.com/org/repo", webURL)
+
+	// Test case: single-segment path is rejected.
+	_, err = parseSCPURL("git@github.com:user")
+	require.ErrorIs(t, err, ErrInvalidRepositoryPath)
 
 	// Test case: empty path.
-	emptyPathURL := "git@github.com:/"
-	_, err = parseSSHURL(emptyPathURL)
-	assert.ErrorContains(t, err, ErrEmptyRepositoryPath)
+	_, err = parseSCPURL("git@github.com:/")
+	require.ErrorIs(t, err, ErrEmptyRepositoryPath)
+
+	// Test case: missing host.
+	_, err = parseSCPURL(":org/repo.git")
+	require.ErrorIs(t, err, ErrUnsupportedURLFormat)
 }
 
 func TestBuildWebURL(t *testing.T) {
@@ -247,6 +290,18 @@ func TestBuildWebURL(t *testing.T) {
 			path:    ".git",
 			wantErr: true,
 		},
+		{
+			name:    "single segment path",
+			host:    "github.com",
+			path:    "onlyuser",
+			wantErr: true,
+		},
+		{
+			name:    "invalid host produces invalid url",
+			host:    "bad host",
+			path:    "org/repo",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +316,33 @@ func TestBuildWebURL(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsSCPLikeURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		remoteURL string
+		want      bool
+	}{
+		{name: "git@ scp form", remoteURL: "git@github.com:org/repo.git", want: true},
+		{name: "scp without user", remoteURL: "github.com:org/repo.git", want: true},
+		{name: "custom user scp", remoteURL: "org-ssh@github.com:org/repo.git", want: true},
+		{name: "https url", remoteURL: "https://github.com/org/repo.git", want: false},
+		{name: "ssh url with scheme", remoteURL: "ssh://git@github.com/org/repo.git", want: false},
+		{name: "git url with scheme", remoteURL: "git://github.com/org/repo.git", want: false},
+		{name: "no colon", remoteURL: "github.com/org/repo", want: false},
+		{name: "colon after slash", remoteURL: "/path/to:repo", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isSCPLikeURL(tt.remoteURL))
 		})
 	}
 }


### PR DESCRIPTION
## Что изменилось

Рефакторинг разбора remote-URL: устранены качественные/корректностные замечания, найденные при ревью. Изменения только в логике приложения и тестах (плюс мелкий `.gitignore`), без изменения внешнего интерфейса CLI.

### Основное
- **Sentinel-ошибки.** Строковые константы ошибок заменены на `var Err… = errors.New(...)` с оборачиванием `%w` — теперь ошибки проверяемы через `errors.Is`. Удалена мёртвая константа `ErrOriginRemoteNotFound`.
- **Поддержка `git://`.** Добавлена обработка протокола `git://`; для `ssh`/`git` транспортный порт отбрасывается при построении web-URL (`ssh://git@host:22/...` → `https://host/...`).
- **scp-формат без `git@`.** Новый `isSCPLikeURL` распознаёт `[user@]host:path` до `url.Parse` (иначе парсер принимает `host` за схему). `parseSSHURL` обобщён в `parseSCPURL`: поддерживает `host:org/repo`, `user@host:org/repo` и т.п.
- **Единая валидация пути.** Проверка «минимум `owner/repo`» вынесена в `buildWebURL` и применяется ко всем форматам (раньше `https://host/onlyuser` молча проходил).
- **Defense-in-depth.** Итоговая строка валидируется как корректный `https`-URL с непустым хостом перед выводом/открытием.

### Тесты
- Добавлены кейсы: ssh-порт, `git://`, scp без/с кастомным юзером, single-segment reject, битый хост, отдельный `TestIsSCPLikeURL`.
- Строковые ассерты переведены на `require.ErrorIs`.
- Покрытие 60.8% → 65.9%.

Локально зелёные: `go build`, `go vet`, `go test`, `golangci-lint` (0 issues).