### PR TITLE
release: 0.6.1 — self-hosted support, test coverage, macOS Gatekeeper fix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,3 +71,13 @@ homebrew_casks:
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
+    # The binary is not signed/notarized with an Apple Developer ID, so macOS
+    # Gatekeeper quarantines it ("Apple could not verify ... is free of
+    # malware"). Strip the quarantine attribute on install so the cask works
+    # out of the box.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/repo-opener"]
+          end

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -31,56 +32,73 @@ var (
 	ErrUnsupportedURLFormat  = errors.New("unsupported URL format")
 	ErrInvalidSSHURL         = errors.New("invalid SSH URL format")
 	ErrUnsupportedScheme     = errors.New("unsupported scheme")
-	ErrUnsupportedSSHUser    = errors.New("unsupported SSH username")
 	ErrInvalidResultURL      = errors.New("invalid resulting URL")
 )
 
 var (
-	Version     = "dev"     //nolint:gochecknoglobals // This is normal
-	Commit      = "none"    //nolint:gochecknoglobals // This is normal
-	Date        = "unknown" //nolint:gochecknoglobals // This is normal
-	BuiltBy     = "unknown" //nolint:gochecknoglobals // This is normal
-	versionFlag bool        //nolint:gochecknoglobals // This is normal
-	remoteName  string      //nolint:gochecknoglobals // This is normal
-	openFlag    bool        //nolint:gochecknoglobals // This is normal
+	Version = "dev"     //nolint:gochecknoglobals // Set via -ldflags at build time.
+	Commit  = "none"    //nolint:gochecknoglobals // Set via -ldflags at build time.
+	Date    = "unknown" //nolint:gochecknoglobals // Set via -ldflags at build time.
+	BuiltBy = "unknown" //nolint:gochecknoglobals // Set via -ldflags at build time.
 )
 
 func main() {
-	flag.BoolVar(&versionFlag, "version", false, "Print version information and exit")
-	flag.BoolVar(&openFlag, "open", false, "Open the remote URL in the default browser")
-	flag.BoolVar(&openFlag, "o", false, "Open the remote URL in the default browser (shorthand)")
-	flag.StringVar(&remoteName, "remote", "origin", "Remote name to use (default: origin)")
+	if err := run(os.Args[1:], os.Stdout, browser.OpenURL); err != nil {
+		exitWithError(err)
+	}
+}
 
-	flag.Parse()
+// run содержит всю логику CLI и вынесен из main для тестируемости:
+// out принимает обычный вывод, openURL — функцию открытия в браузере.
+func run(args []string, out io.Writer, openURL func(string) error) error {
+	var (
+		versionFlag bool
+		openFlag    bool
+		remoteName  string
+	)
+
+	fs := flag.NewFlagSet("repo-opener", flag.ContinueOnError)
+	fs.SetOutput(out)
+	fs.BoolVar(&versionFlag, "version", false, "Print version information and exit")
+	fs.BoolVar(&openFlag, "open", false, "Open the remote URL in the default browser")
+	fs.BoolVar(&openFlag, "o", false, "Open the remote URL in the default browser (shorthand)")
+	fs.StringVar(&remoteName, "remote", "origin", "Remote name to use (default: origin)")
+
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
 
 	if versionFlag {
-		fmt.Println("Version:", Version)
-		fmt.Printf("Build info: commit %s, built at %s, by %s\n", Commit, Date, BuiltBy)
-		return
+		fmt.Fprintln(out, "Version:", Version)
+		fmt.Fprintf(out, "Build info: commit %s, built at %s, by %s\n", Commit, Date, BuiltBy)
+
+		return nil
 	}
 
 	repo, err := git.PlainOpen(".")
 	if err != nil {
-		exitWithError(fmt.Errorf("not a git repository: %w", err))
+		return fmt.Errorf("not a git repository: %w", err)
 	}
 
 	remoteURL, err := getRemoteURL(repo, remoteName)
 	if err != nil {
-		exitWithError(err)
+		return err
 	}
 
 	webURL, err := parseRemoteURL(remoteURL)
 	if err != nil {
-		exitWithError(err)
+		return err
 	}
 
-	fmt.Println(webURL)
+	fmt.Fprintln(out, webURL)
 
 	if openFlag {
-		if err := browser.OpenURL(webURL); err != nil {
-			exitWithError(fmt.Errorf("failed to open browser: %w", err))
+		if err := openURL(webURL); err != nil {
+			return fmt.Errorf("failed to open browser: %w", err)
 		}
 	}
+
+	return nil
 }
 
 func getRemoteURL(repo *git.Repository, name string) (string, error) {
@@ -140,12 +158,11 @@ func parseStructuredURL(u *url.URL) (string, error) {
 		path = u.Path
 	case "ssh", "git":
 		// Для ssh/git порт относится к транспорту, а не к веб-интерфейсу,
-		// поэтому отбрасываем его через Hostname().
+		// поэтому отбрасываем его через Hostname(). Имя пользователя для
+		// веб-URL не нужно, поэтому любые пользователи допустимы (self-hosted
+		// инсталляции нередко используют не git-пользователя).
 		host = u.Hostname()
 		path = u.Path
-		if u.Scheme == "ssh" && u.User != nil && u.User.Username() != "git" {
-			return "", fmt.Errorf("%w: %s", ErrUnsupportedSSHUser, u.User.Username())
-		}
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedScheme, u.Scheme)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"errors"
 	"net/url"
 	"os"
 	"testing"
@@ -167,10 +169,18 @@ func TestParseStructuredURL(t *testing.T) {
 	require.NoError(t, err, "Expected no error for git scheme")
 	assert.Equal(t, "https://github.com/jtprogru/repo-opener", webURL)
 
-	// Test case: ssh scheme with invalid user.
-	u, _ = url.Parse("ssh://user@github.com/jtprogru/repo-opener.git") //nolint:errcheck // Ignore error from url.Parse
-	_, err = parseStructuredURL(u)
-	require.ErrorIs(t, err, ErrUnsupportedSSHUser)
+	// Test case: ssh scheme with a non-git user (self-hosted) is accepted;
+	// the username is irrelevant to the resulting web URL.
+	u, _ = url.Parse("ssh://gitlab@git.company.com/group/repo.git") //nolint:errcheck // Ignore error from url.Parse
+	webURL, err = parseStructuredURL(u)
+	require.NoError(t, err, "Expected no error for non-git ssh user")
+	assert.Equal(t, "https://git.company.com/group/repo", webURL)
+
+	// Test case: ssh scheme without a user (anonymous) is accepted.
+	u, _ = url.Parse("ssh://github.com/org/repo.git") //nolint:errcheck // Ignore error from url.Parse
+	webURL, err = parseStructuredURL(u)
+	require.NoError(t, err, "Expected no error for anonymous ssh")
+	assert.Equal(t, "https://github.com/org/repo", webURL)
 
 	// Test case: unsupported scheme.
 	u, _ = url.Parse("ftp://example.com/repo.git") //nolint:errcheck // Ignore error from url.Parse
@@ -203,6 +213,10 @@ func TestParseSCPURL(t *testing.T) {
 	// Test case: missing host.
 	_, err = parseSCPURL(":org/repo.git")
 	require.ErrorIs(t, err, ErrUnsupportedURLFormat)
+
+	// Test case: no colon at all (defensive; unreachable via parseRemoteURL).
+	_, err = parseSCPURL("github.com")
+	require.ErrorIs(t, err, ErrInvalidSSHURL)
 }
 
 func TestBuildWebURL(t *testing.T) {
@@ -246,6 +260,25 @@ func TestBuildWebURL(t *testing.T) {
 			path: "org/repo.git",
 			want: "https://bitbucket.org/org/repo",
 		},
+		{
+			name: "www.bitbucket.org normalized",
+			host: "www.bitbucket.org",
+			path: "org/repo.git",
+			want: "https://bitbucket.org/org/repo",
+		},
+		// GitLab-подгруппы и глубокая вложенность путей сохраняются.
+		{
+			name: "gitlab subgroup preserved",
+			host: "gitlab.com",
+			path: "group/subgroup/repo.git",
+			want: "https://gitlab.com/group/subgroup/repo",
+		},
+		{
+			name: "deeply nested subgroups preserved",
+			host: "gitlab.company.com",
+			path: "team/group/subgroup/repo.git",
+			want: "https://gitlab.company.com/team/group/subgroup/repo",
+		},
 		// Приватные инсталляции (не изменяются).
 		{
 			name: "private gitlab preserved",
@@ -277,6 +310,18 @@ func TestBuildWebURL(t *testing.T) {
 			path: "org/repo",
 			want: "https://forgejo.example.com/org/repo",
 		},
+		{
+			name: "gitlab under url subpath preserved",
+			host: "example.com",
+			path: "gitlab/group/repo.git",
+			want: "https://example.com/gitlab/group/repo",
+		},
+		{
+			name: "host with web port preserved",
+			host: "gitlab.company.com:8443",
+			path: "group/repo.git",
+			want: "https://gitlab.company.com:8443/group/repo",
+		},
 		// Ошибки.
 		{
 			name:    "empty path",
@@ -299,6 +344,12 @@ func TestBuildWebURL(t *testing.T) {
 		{
 			name:    "invalid host produces invalid url",
 			host:    "bad host",
+			path:    "org/repo",
+			wantErr: true,
+		},
+		{
+			name:    "empty host produces invalid url",
+			host:    "",
 			path:    "org/repo",
 			wantErr: true,
 		},
@@ -345,6 +396,240 @@ func TestIsSCPLikeURL(t *testing.T) {
 			assert.Equal(t, tt.want, isSCPLikeURL(tt.remoteURL))
 		})
 	}
+}
+
+func TestParseRemoteURLSelfHosted(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		remote  string
+		want    string
+		wantErr bool
+	}{
+		// HTTPS self-hosted: веб-порт сохраняется.
+		{
+			name:   "https self-hosted gitlab with web port",
+			remote: "https://gitlab.company.com:8443/group/repo.git",
+			want:   "https://gitlab.company.com:8443/group/repo",
+		},
+		// HTTPS со встроенными кредами — креды отбрасываются.
+		{ //nolint:gosec // Test data with fake credentials, not a real secret.
+			name:   "https with embedded credentials",
+			remote: "https://user:token@git.internal.io/team/project.git",
+			want:   "https://git.internal.io/team/project",
+		},
+		// HTTP (insecure) self-hosted — в вебе всё равно https.
+		{
+			name:   "http self-hosted upgraded to https",
+			remote: "http://git.internal/team/repo.git",
+			want:   "https://git.internal/team/repo",
+		},
+		// GitLab-подгруппы (глубокая вложенность).
+		{
+			name:   "https gitlab nested subgroups",
+			remote: "https://gitlab.com/group/sub/repo.git",
+			want:   "https://gitlab.com/group/sub/repo",
+		},
+		// GitLab под subpath (relative URL root).
+		{
+			name:   "https self-hosted gitlab under subpath",
+			remote: "https://example.com/gitlab/group/repo.git",
+			want:   "https://example.com/gitlab/group/repo",
+		},
+		// ssh-схема: нестандартный порт + не-git пользователь (self-hosted).
+		{
+			name:   "ssh custom port and non-git user",
+			remote: "ssh://gitlab@git.company.com:2222/group/repo.git",
+			want:   "https://git.company.com/group/repo",
+		},
+		// ssh-схема без пользователя (анонимный).
+		{
+			name:   "ssh anonymous self-hosted",
+			remote: "ssh://code.example.org/org/repo.git",
+			want:   "https://code.example.org/org/repo",
+		},
+		// git-протокол с нестандартным портом.
+		{
+			name:   "git protocol with port",
+			remote: "git://git.example.com:9418/org/repo.git",
+			want:   "https://git.example.com/org/repo",
+		},
+		// scp self-hosted Gitea с кастомным пользователем.
+		{
+			name:   "scp gitea custom user",
+			remote: "forgejo@code.example.org:org/repo.git",
+			want:   "https://code.example.org/org/repo",
+		},
+		// scp self-hosted без пользователя.
+		{
+			name:   "scp self-hosted without user",
+			remote: "git.internal.io:team/project.git",
+			want:   "https://git.internal.io/team/project",
+		},
+		// scp с глубокой вложенностью подгрупп.
+		{
+			name:   "scp gitlab nested subgroups",
+			remote: "git@gitlab.company.com:team/group/sub/repo.git",
+			want:   "https://gitlab.company.com/team/group/sub/repo",
+		},
+		// scp с завершающим слэшем и .git.
+		{
+			name:   "scp trailing slash and dot-git",
+			remote: "git@gitea.example.com:org/repo.git/",
+			want:   "https://gitea.example.com/org/repo",
+		},
+		// Ошибки: одиночный сегмент пути на self-hosted.
+		{
+			name:    "self-hosted single-segment path rejected",
+			remote:  "https://git.internal/onlyrepo",
+			wantErr: true,
+		},
+		// Ошибки: неподдерживаемая схема.
+		{
+			name:    "ftp scheme rejected",
+			remote:  "ftp://git.internal/org/repo.git",
+			wantErr: true,
+		},
+		// Ошибки: локальный путь без схемы и scp-двоеточия.
+		{
+			name:    "local path rejected",
+			remote:  "/home/user/repo",
+			wantErr: true,
+		},
+		// Ошибки: произвольная строка.
+		{
+			name:    "plain string rejected",
+			remote:  "justastring",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseRemoteURL(tt.remote)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	noopOpen := func(string) error { return nil }
+
+	createOriginRepo := func(t *testing.T, remoteURL string) {
+		t.Helper()
+
+		repoPath := initTempRepo(t)
+		withChdir(t, repoPath)
+
+		repo, err := git.PlainOpen(repoPath)
+		require.NoError(t, err)
+
+		_, err = repo.CreateRemote(&config.RemoteConfig{
+			Name: "origin",
+			URLs: []string{remoteURL},
+		})
+		require.NoError(t, err)
+	}
+
+	t.Run("prints web url for origin", func(t *testing.T) {
+		createOriginRepo(t, "git@github.com:org/repo.git")
+
+		var buf bytes.Buffer
+		require.NoError(t, run(nil, &buf, noopOpen))
+		assert.Equal(t, "https://github.com/org/repo\n", buf.String())
+	})
+
+	t.Run("open flag invokes opener with self-hosted url", func(t *testing.T) {
+		createOriginRepo(t, "https://gitlab.company.com:8443/group/repo.git")
+
+		var (
+			opened string
+			buf    bytes.Buffer
+		)
+
+		err := run([]string{"-o"}, &buf, func(u string) error {
+			opened = u
+
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "https://gitlab.company.com:8443/group/repo", opened)
+	})
+
+	t.Run("custom remote flag", func(t *testing.T) {
+		repoPath := initTempRepo(t)
+		withChdir(t, repoPath)
+
+		repo, err := git.PlainOpen(repoPath)
+		require.NoError(t, err)
+
+		_, err = repo.CreateRemote(&config.RemoteConfig{
+			Name: "upstream",
+			URLs: []string{"git@gitea.example.com:team/proj.git"},
+		})
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		require.NoError(t, run([]string{"--remote", "upstream"}, &buf, noopOpen))
+		assert.Equal(t, "https://gitea.example.com/team/proj\n", buf.String())
+	})
+
+	t.Run("version flag", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.NoError(t, run([]string{"--version"}, &buf, noopOpen))
+		assert.Contains(t, buf.String(), "Version:")
+		assert.Contains(t, buf.String(), "Build info:")
+	})
+
+	t.Run("not a git repository", func(t *testing.T) {
+		withChdir(t, t.TempDir())
+
+		var buf bytes.Buffer
+		err := run(nil, &buf, noopOpen)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("remote not found", func(t *testing.T) {
+		repoPath := initTempRepo(t)
+		withChdir(t, repoPath)
+
+		var buf bytes.Buffer
+		require.ErrorIs(t, run(nil, &buf, noopOpen), ErrRemoteNotFound)
+	})
+
+	t.Run("unsupported remote url", func(t *testing.T) {
+		createOriginRepo(t, "ftp://example.com/repo.git")
+
+		var buf bytes.Buffer
+		require.ErrorIs(t, run(nil, &buf, noopOpen), ErrUnsupportedScheme)
+	})
+
+	t.Run("open failure is propagated", func(t *testing.T) {
+		createOriginRepo(t, "git@github.com:org/repo.git")
+
+		failOpen := func(string) error { return errors.New("boom") }
+
+		var buf bytes.Buffer
+		err := run([]string{"-o"}, &buf, failOpen)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to open browser")
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		var buf bytes.Buffer
+		require.Error(t, run([]string{"--nonexistent"}, &buf, noopOpen))
+	})
 }
 
 func initTempRepo(t *testing.T) string {


### PR DESCRIPTION
Подготовка релиза **0.6.1**.

## fix(goreleaser): macOS Gatekeeper
Бинарник не подписан Apple Developer ID → Gatekeeper выдаёт «Apple could not verify ... is free of malware». Добавлен hook в `homebrew_casks`, снимающий `com.apple.quarantine` при установке cask — теперь `brew install` работает из коробки на macOS.

> Прямые скачивания tar.gz всё ещё требуют ручного `xattr -dr com.apple.quarantine <bin>` (полное решение — нотаризация, требует платного Apple Developer Program).

## test: покрытие и self-hosted
- `run()` вынесен из `main()` для тестируемости (инъекция вывода и опенера).
- Снято ограничение «ssh-пользователь только `git`» — ломало self-hosted (`ssh://gitlab@git.company.com/...`); имя пользователя не нужно для web-URL.
- Новый табличный тест под нетипичные self-hosted конфигурации: сохранение веб-порта, отбрасывание транспортного порта, отбрасывание встроенных кредов, GitLab subgroups, subpath, http→https, scp-варианты.
- Покрыты ранее непокрытые ветки. **Покрытие 65.9% → 94.3%.**

Локально зелёные: `go build`, `go vet`, `go test`, `golangci-lint` (0 issues), `goreleaser check`.