### PR TITLE
ci(goreleaser): bump ghaction-import-gpg to v7 (Node 24)

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -25,7 +25,7 @@ jobs:
           check-latest: true
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
`crazy-max/ghaction-import-gpg@v6` работает на устаревшем рантайме Node.js 20, который GitHub принудительно переводит на Node 24 с 16 июня 2026.

`v7.0.0` переключает дефолтный рантайм на **Node 24**. Ломающих изменений в API нет: инпуты `gpg_private_key`/`passphrase` и выход `fingerprint` не изменились (основные изменения — рантайм + внутренний переход на ESM).

Проверится при следующем релизном теге (workflow триггерится только на push тега).